### PR TITLE
feat(MELHORIA-007): gerenciar usuários — e-mail duplicado + exclusão + link expirado

### DIFF
--- a/src/app/(auth)/update-password/page.tsx
+++ b/src/app/(auth)/update-password/page.tsx
@@ -3,7 +3,7 @@
 import { useActionState } from 'react'
 import { useFormStatus } from 'react-dom'
 import { updatePassword } from './actions'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 function SubmitButton() {
   const { pending } = useFormStatus()
@@ -68,6 +68,19 @@ function PasswordInput({ id, name, label, placeholder }: { id: string; name: str
 
 export default function UpdatePasswordPage() {
   const [state, formAction] = useActionState(updatePassword, null)
+  const [linkError, setLinkError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const authError = params.get('auth_error')
+    if (authError) {
+      setLinkError(
+        authError === 'otp_expired'
+          ? 'Seu link de convite expirou. Solicite um novo convite ao administrador.'
+          : 'Link de convite inválido ou já utilizado. Solicite um novo convite ao administrador.'
+      )
+    }
+  }, [])
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-950 to-slate-900 flex items-center justify-center p-4">
@@ -87,6 +100,15 @@ export default function UpdatePasswordPage() {
           <p className="text-sm text-gray-500 mb-6">
             Escolha uma senha com pelo menos 8 caracteres.
           </p>
+
+          {linkError && (
+            <div className="mb-4 flex gap-2 items-start p-3 rounded-lg bg-amber-50 border border-amber-200 text-amber-800 text-sm">
+              <svg className="w-4 h-4 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+              </svg>
+              <span>{linkError}</span>
+            </div>
+          )}
 
           {state?.error && (
             <div className="mb-4 flex gap-2 items-start p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">

--- a/src/app/(dashboard)/area-usuario/gerenciar-usuarios/actions.ts
+++ b/src/app/(dashboard)/area-usuario/gerenciar-usuarios/actions.ts
@@ -44,6 +44,11 @@ export async function createUserAction(formData: FormData): Promise<ActionResult
   const { client: admin, error: clientError } = getAdminClient()
   if (!admin) return { success: false, error: clientError! }
 
+  // Verificar se e-mail já existe
+  const { data: { users: allUsers } } = await admin.auth.admin.listUsers()
+  const emailJaExiste = allUsers.some(u => u.email?.toLowerCase() === email)
+  if (emailJaExiste) return { success: false, error: 'Este e-mail já está cadastrado no sistema.' }
+
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://elopar-webapp.vercel.app'
   const { data, error } = await admin.auth.admin.inviteUserByEmail(email, {
     data: { full_name: fullName, role },
@@ -135,6 +140,22 @@ export async function updateUserPermissionsAction(
 
   if (error) return { success: false, error: error.message }
 
+  revalidatePath('/area-usuario/gerenciar-usuarios')
+  return { success: true }
+}
+
+export async function deleteUserAction(userId: string): Promise<ActionResult> {
+  const adminId = await requireAdmin()
+  if (!adminId) return { success: false, error: 'Acesso negado' }
+  if (adminId === userId) return { success: false, error: 'Não é possível excluir o próprio usuário' }
+
+  const { client: admin, error: clientError } = getAdminClient()
+  if (!admin) return { success: false, error: clientError! }
+
+  const { error } = await admin.auth.admin.deleteUser(userId)
+  if (error) return { success: false, error: error.message }
+
+  // profiles é deletado automaticamente via CASCADE DELETE
   revalidatePath('/area-usuario/gerenciar-usuarios')
   return { success: true }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Script from "next/script";
+import { AuthHashHandler } from '@/components/auth/auth-hash-handler';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -38,6 +39,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <AuthHashHandler />
         {children}
         <Script id="sw-register" strategy="afterInteractive">{`
           if ('serviceWorker' in navigator) {

--- a/src/components/auth/auth-hash-handler.tsx
+++ b/src/components/auth/auth-hash-handler.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+export function AuthHashHandler() {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const hash = window.location.hash
+    if (!hash) return
+
+    const params = new URLSearchParams(hash.slice(1))
+    const error = params.get('error')
+    const errorCode = params.get('error_code')
+
+    if (error) {
+      const code = errorCode ?? 'invalid_link'
+      router.replace(`/update-password?auth_error=${code}`)
+    }
+  }, [router])
+
+  return null
+}

--- a/src/components/gerenciar-usuarios/excluir-usuario-modal.tsx
+++ b/src/components/gerenciar-usuarios/excluir-usuario-modal.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { deleteUserAction } from '@/app/(dashboard)/area-usuario/gerenciar-usuarios/actions'
+
+interface Props {
+  userId: string
+  userName: string
+  onClose: () => void
+}
+
+export function ExcluirUsuarioModal({ userId, userName, onClose }: Props) {
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  function handleDelete() {
+    setError(null)
+    startTransition(async () => {
+      const result = await deleteUserAction(userId)
+      if (result.success) {
+        onClose()
+      } else {
+        setError(result.error ?? 'Erro ao excluir usuário')
+      }
+    })
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl w-full max-w-md shadow-2xl">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <h2 className="text-base font-bold text-gray-900">Excluir Usuário</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none">&times;</button>
+        </div>
+
+        <div className="px-6 py-5 space-y-4">
+          <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+            ⚠️ Esta ação é <strong>irreversível</strong>. O usuário e todos os seus dados serão permanentemente removidos.
+          </div>
+
+          <p className="text-sm text-gray-700">
+            Tem certeza que deseja excluir o usuário <strong>{userName}</strong>?
+          </p>
+
+          {error && (
+            <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-xs text-red-700">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-3 justify-end px-6 py-4 border-t border-gray-100">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            className="px-4 py-2 text-sm text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={isPending}
+            className="px-4 py-2 text-sm font-semibold text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+          >
+            {isPending ? 'Excluindo...' : 'Excluir permanentemente'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/gerenciar-usuarios/usuarios-table.tsx
+++ b/src/components/gerenciar-usuarios/usuarios-table.tsx
@@ -5,7 +5,8 @@ import { formatDate } from '@/lib/utils/formatting'
 import { NovoUsuarioModal } from './novo-usuario-modal'
 import { DesativarUsuarioModal } from './desativar-usuario-modal'
 import { PermissionsModal } from './permissions-modal'
-import { reactivateUserAction, resendInviteAction } from '@/app/(dashboard)/area-usuario/gerenciar-usuarios/actions'
+import { reactivateUserAction, resendInviteAction, deleteUserAction } from '@/app/(dashboard)/area-usuario/gerenciar-usuarios/actions'
+import { ExcluirUsuarioModal } from './excluir-usuario-modal'
 import type { UserPermissions } from '@/types/permissions'
 
 export type UserStatus = 'ativo' | 'pendente' | 'desativado'
@@ -67,6 +68,7 @@ export function UsuariosTable({ users, currentUserId }: Props) {
   const [editingPermissions, setEditingPermissions] = useState<UserRow | null>(null)
   const [pendingAction, setPendingAction] = useState<string | null>(null)
   const [resendFeedback, setResendFeedback] = useState<{ id: string; ok: boolean } | null>(null)
+  const [deleting, setDeleting] = useState<UserRow | null>(null)
 
   const counts = {
     todos: users.length,
@@ -248,6 +250,16 @@ export function UsuariosTable({ users, currentUserId }: Props) {
                           >
                             🔑
                           </button>
+                          {!isSelf && (
+                            <button
+                              onClick={() => setDeleting(u)}
+                              disabled={isLoading}
+                              title="Excluir usuário permanentemente"
+                              className="border border-gray-200 rounded-md px-2 py-1 text-xs text-gray-500 hover:border-red-400 hover:text-red-600 disabled:opacity-40 transition-colors"
+                            >
+                              🗑️
+                            </button>
+                          )}
                         </div>
                       </td>
                     </tr>
@@ -274,6 +286,13 @@ export function UsuariosTable({ users, currentUserId }: Props) {
           currentRole={editingPermissions.role}
           currentPermissions={editingPermissions.permissions ?? null}
           onClose={() => setEditingPermissions(null)}
+        />
+      )}
+      {deleting && (
+        <ExcluirUsuarioModal
+          userId={deleting.id}
+          userName={deleting.full_name ?? deleting.email}
+          onClose={() => setDeleting(null)}
         />
       )}
     </>


### PR DESCRIPTION
## O que foi feito

- Valida e-mail duplicado antes de enviar convite (retorna erro claro na UI)
- Adiciona `deleteUserAction` com hard delete via `admin.auth.admin.deleteUser()`
- `profiles` removido automaticamente via CASCADE DELETE
- Modal de confirmação `ExcluirUsuarioModal` com aviso de ação irreversível
- Botão 🗑️ na tabela de usuários (desabilitado para o próprio admin)
- `AuthHashHandler` intercepta `#error=` do Supabase e redireciona para `/update-password?auth_error=`
- Mensagem amigável na página `/update-password` quando link expirado ou inválido

## Como testar

- Tentar criar usuário com e-mail já existente → mostra erro "Este e-mail já está cadastrado"
- Clicar em 🗑️ → abre modal com aviso de irreversibilidade
- Confirmar exclusão → usuário some da lista
- Clicar em link de convite expirado → vai para `/update-password` com mensagem de link expirado (não tela quebrada)

🤖 Generated with Claude Code