### PR TITLE
feat(MELHORIA-011): sistema de notificações + @menção em notas

### DIFF
--- a/scripts/migrations/20260414_create_notifications.sql
+++ b/scripts/migrations/20260414_create_notifications.sql
@@ -1,0 +1,28 @@
+-- MELHORIA-011: Criar tabela notifications
+-- Executar via Supabase SQL Editor ou Cowork antes de fazer deploy desta branch
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tipo TEXT NOT NULL,
+  mensagem TEXT NOT NULL,
+  link TEXT,
+  lida BOOLEAN DEFAULT FALSE,
+  criado_em TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- RLS
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "notifications_select_own"
+  ON notifications FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "notifications_update_own"
+  ON notifications FOR UPDATE
+  USING (user_id = auth.uid());
+
+-- Service role pode inserir (usado pelo insertNotification via admin client)
+CREATE POLICY "notifications_insert_service"
+  ON notifications FOR INSERT
+  WITH CHECK (true);

--- a/src/actions/professional-notes.ts
+++ b/src/actions/professional-notes.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@/lib/supabase/server'
 import { revalidatePath } from 'next/cache'
+import { insertNotification } from '@/lib/notifications'
 
 type ActionResult = { success: boolean; error?: string }
 
@@ -44,6 +45,27 @@ export async function createNoteAction(
     })
 
   if (error) return { success: false, error: error.message }
+
+  // Detectar @menções e notificar usuários mencionados
+  const mentionRegex = /@(\S+)/g
+  const mentions = [...trimmed.matchAll(mentionRegex)].map(m => m[1].toLowerCase())
+  if (mentions.length > 0) {
+    const { data: profiles } = await supabase.from('profiles').select('id, full_name')
+    for (const profile of profiles ?? []) {
+      const nameLower = (profile.full_name ?? '').toLowerCase().replace(/\s+/g, '')
+      if (
+        nameLower.length >= 3 &&
+        mentions.some(m => nameLower.includes(m) || m.includes(nameLower.slice(0, 4)))
+      ) {
+        await insertNotification({
+          user_id: profile.id,
+          tipo: 'mention',
+          mensagem: 'Você foi mencionado em uma nota de profissional.',
+          link: `/profissionais/${professionalId}`,
+        })
+      }
+    }
+  }
 
   revalidatePath(`/profissionais/${professionalId}`)
   return { success: true }

--- a/src/app/(dashboard)/area-usuario/gerenciar-usuarios/actions.ts
+++ b/src/app/(dashboard)/area-usuario/gerenciar-usuarios/actions.ts
@@ -5,6 +5,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { revalidatePath } from 'next/cache'
 import type { UserPermissions } from '@/types/permissions'
 import { logAudit } from '@/lib/audit'
+import { insertNotification } from '@/lib/notifications'
 
 type ActionResult = { success: boolean; error?: string }
 
@@ -71,6 +72,17 @@ export async function createUserAction(formData: FormData): Promise<ActionResult
     dados_depois: { email, full_name: fullName, role },
   })
 
+  // Notificar todos os admins sobre novo convite
+  const { data: admins } = await admin.from('profiles').select('id').eq('role', 'admin')
+  for (const a of admins ?? []) {
+    await insertNotification({
+      user_id: a.id,
+      tipo: 'user_invited',
+      mensagem: `Novo usuário convidado: ${fullName} (${email})`,
+      link: '/area-usuario/gerenciar-usuarios',
+    })
+  }
+
   revalidatePath('/area-usuario/gerenciar-usuarios')
   return { success: true }
 }
@@ -93,6 +105,17 @@ export async function deactivateUserAction(userId: string): Promise<ActionResult
     dados_antes: { status: 'ativo' },
     dados_depois: { status: 'desativado' },
   })
+
+  // Notificar todos os admins sobre desativação
+  const { data: admins } = await admin.from('profiles').select('id').eq('role', 'admin')
+  for (const a of admins ?? []) {
+    await insertNotification({
+      user_id: a.id,
+      tipo: 'user_deactivated',
+      mensagem: `Usuário ${userId} foi desativado.`,
+      link: '/area-usuario/gerenciar-usuarios',
+    })
+  }
 
   revalidatePath('/area-usuario/gerenciar-usuarios')
   return { success: true }

--- a/src/app/(dashboard)/notificacoes/actions.ts
+++ b/src/app/(dashboard)/notificacoes/actions.ts
@@ -20,3 +20,16 @@ export async function markAllAsRead() {
     .is('read_at', null)
   revalidatePath('/notificacoes')
 }
+
+export async function markSistemaAsRead() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (supabase as any)
+    .from('notifications')
+    .update({ lida: true })
+    .eq('user_id', user.id)
+    .eq('lida', false)
+  revalidatePath('/notificacoes')
+}

--- a/src/app/(dashboard)/notificacoes/page.tsx
+++ b/src/app/(dashboard)/notificacoes/page.tsx
@@ -1,10 +1,20 @@
 import { createClient } from '@/lib/supabase/server'
 import { formatDate } from '@/lib/utils/formatting'
-import { markAsRead, markAllAsRead } from './actions'
+import { markAsRead, markAllAsRead, markSistemaAsRead } from './actions'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Notificações',
+}
+
+interface SistemaNotif {
+  id: string
+  user_id: string
+  tipo: string
+  mensagem: string
+  link: string | null
+  lida: boolean
+  criado_em: string
 }
 
 const URGENCY_CONFIG: Record<string, { label: string; icon: string; bg: string; border: string; text: string }> = {
@@ -14,18 +24,53 @@ const URGENCY_CONFIG: Record<string, { label: string; icon: string; bg: string; 
   attention:{ label: '≤90 dias',    icon: '🔵', bg: 'bg-blue-50',   border: 'border-blue-200',   text: 'text-blue-700'   },
 }
 
-export default async function NotificacoesPage() {
-  const supabase = await createClient()
+const TIPO_LABELS: Record<string, { label: string; icon: string }> = {
+  mention:          { label: 'Menção',          icon: '💬' },
+  user_invited:     { label: 'Novo usuário',    icon: '👤' },
+  user_deactivated: { label: 'Desativação',     icon: '⛔' },
+}
 
-  const { data: notifications } = await supabase
+interface SearchParams {
+  tipo?: string
+}
+
+interface NotificacoesPageProps {
+  searchParams: Promise<SearchParams>
+}
+
+export default async function NotificacoesPage({ searchParams }: NotificacoesPageProps) {
+  const supabase = await createClient()
+  const params = await searchParams
+  const tipoFilter = params.tipo ?? ''
+
+  // Renovações de contrato
+  const { data: contractNotifs } = await supabase
     .from('contract_notifications')
     .select('*')
     .order('created_at', { ascending: false })
     .limit(100)
 
-  const all = notifications ?? []
-  const unread = all.filter((n) => !n.read_at)
-  const read = all.filter((n) => n.read_at)
+  // Notificações do sistema (tabela não está nos tipos gerados ainda — cast necessário)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabaseAny = supabase as any
+  let sistemaQuery = supabaseAny
+    .from('notifications')
+    .select('*')
+    .order('criado_em', { ascending: false })
+    .limit(100)
+
+  if (tipoFilter) sistemaQuery = sistemaQuery.eq('tipo', tipoFilter)
+
+  const { data: sistemaNotifs } = await sistemaQuery as { data: SistemaNotif[] | null }
+
+  const allContracts = contractNotifs ?? []
+  const unreadContracts = allContracts.filter((n) => !n.read_at)
+  const readContracts = allContracts.filter((n) => n.read_at)
+
+  const allSistema = sistemaNotifs ?? []
+  const unreadSistema = allSistema.filter((n) => !n.lida)
+
+  const totalUnread = unreadContracts.length + unreadSistema.length
 
   return (
     <div className="space-y-6">
@@ -34,107 +79,176 @@ export default async function NotificacoesPage() {
         <div>
           <h1 className="text-xl sm:text-2xl font-semibold text-gray-900">Notificações</h1>
           <p className="mt-0.5 text-xs sm:text-sm text-gray-500">
-            Alertas de renovação de contrato
+            Alertas do sistema e renovações de contrato
           </p>
         </div>
-        {unread.length > 0 && (
-          <form action={markAllAsRead}>
-            <button
-              type="submit"
-              className="text-xs sm:text-sm text-indigo-600 hover:text-indigo-800 font-medium focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded px-2 py-1"
-            >
-              Marcar todas como lidas
-            </button>
-          </form>
+        {totalUnread > 0 && (
+          <div className="flex gap-2">
+            {unreadSistema.length > 0 && (
+              <form action={markSistemaAsRead}>
+                <button
+                  type="submit"
+                  className="text-xs sm:text-sm text-indigo-600 hover:text-indigo-800 font-medium focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded px-2 py-1"
+                >
+                  Marcar sistema como lidas
+                </button>
+              </form>
+            )}
+            {unreadContracts.length > 0 && (
+              <form action={markAllAsRead}>
+                <button
+                  type="submit"
+                  className="text-xs sm:text-sm text-indigo-600 hover:text-indigo-800 font-medium focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded px-2 py-1"
+                >
+                  Marcar renovações como lidas
+                </button>
+              </form>
+            )}
+          </div>
         )}
       </div>
 
-      {all.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20 bg-white rounded-xl border border-gray-200 shadow-sm text-center">
-          <svg className="h-12 w-12 text-gray-300 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-          </svg>
-          <p className="text-gray-500 font-medium">Nenhuma notificação</p>
-          <p className="text-gray-400 text-sm mt-1">O job diário cria alertas para contratos vencendo em ≤90 dias.</p>
+      {/* Seção: Notificações do Sistema */}
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="px-4 sm:px-5 py-3 bg-gray-50 border-b border-gray-100 flex items-center justify-between">
+          <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+            Sistema {unreadSistema.length > 0 && `(${unreadSistema.length} não lidas)`}
+          </span>
+          {/* Filtro por tipo */}
+          <form method="get" className="flex items-center gap-2">
+            <select
+              name="tipo"
+              defaultValue={tipoFilter}
+              className="rounded-lg border border-gray-200 px-2 py-1 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Todos os tipos</option>
+              <option value="mention">Menções</option>
+              <option value="user_invited">Novos usuários</option>
+              <option value="user_deactivated">Desativações</option>
+            </select>
+            <button type="submit" className="px-2 py-1 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors">
+              Filtrar
+            </button>
+            {tipoFilter && (
+              <a href="/notificacoes" className="px-2 py-1 text-xs text-gray-500 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+                Limpar
+              </a>
+            )}
+          </form>
         </div>
-      ) : (
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-          {/* Não lidas */}
-          {unread.length > 0 && (
-            <div>
-              <div className="px-4 sm:px-5 py-3 bg-gray-50 border-b border-gray-100">
-                <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Não lidas ({unread.length})
-                </span>
-              </div>
-              <ul className="divide-y divide-gray-100">
-                {unread.map((n) => {
-                  const cfg = URGENCY_CONFIG[n.urgency]
-                  return (
-                    <li key={n.id} className={`flex items-center justify-between px-4 sm:px-5 py-4 ${cfg.bg}`}>
-                      <div className="flex items-start gap-3 min-w-0">
-                        <span className="text-lg mt-0.5 flex-shrink-0">{cfg.icon}</span>
-                        <div className="min-w-0">
-                          <p className="text-sm font-medium text-gray-900">
-                            {n.professional_name}
-                            {n.client_name && (
-                              <span className="font-normal text-gray-500"> — {n.client_name}</span>
-                            )}
-                          </p>
-                          <p className={`text-xs mt-0.5 ${cfg.text}`}>
-                            Vence em {n.days_until_expiry} dias
-                            {n.renewal_deadline && ` (${formatDate(n.renewal_deadline)})`}
-                          </p>
-                        </div>
-                      </div>
-                      <form action={markAsRead.bind(null, n.id)} className="ml-4 flex-shrink-0">
-                        <button
-                          type="submit"
-                          className="text-xs text-gray-500 hover:text-gray-900 border border-gray-300 rounded px-2.5 py-1 bg-white hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                        >
-                          Marcar como lida
-                        </button>
-                      </form>
-                    </li>
-                  )
-                })}
-              </ul>
-            </div>
-          )}
 
-          {/* Lidas */}
-          {read.length > 0 && (
-            <div>
-              <div className="px-4 sm:px-5 py-3 bg-gray-50 border-b border-gray-100">
-                <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Lidas ({read.length})
-                </span>
-              </div>
-              <ul className="divide-y divide-gray-100">
-                {read.map((n) => {
-                  const cfg = URGENCY_CONFIG[n.urgency]
-                  return (
-                    <li key={n.id} className="flex items-center gap-3 px-4 sm:px-5 py-4 opacity-50">
-                      <span className="text-base flex-shrink-0">{cfg.icon}</span>
-                      <div className="min-w-0">
-                        <p className="text-sm text-gray-700">
-                          {n.professional_name}
-                          {n.client_name && (
-                            <span className="text-gray-400"> — {n.client_name}</span>
-                          )}
-                        </p>
-                        <p className="text-xs text-gray-400 mt-0.5">
-                          Lida em {formatDate(n.read_at)}
-                        </p>
-                      </div>
-                    </li>
-                  )
-                })}
-              </ul>
-            </div>
-          )}
+        {allSistema.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-gray-400">
+            Nenhuma notificação do sistema.
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-100">
+            {allSistema.map((n) => {
+              const tipoInfo = TIPO_LABELS[n.tipo] ?? { label: n.tipo, icon: '🔔' }
+              return (
+                <li key={n.id} className={`flex items-start justify-between px-4 sm:px-5 py-3 ${n.lida ? 'opacity-60' : 'bg-indigo-50/40'}`}>
+                  <div className="flex items-start gap-3 min-w-0">
+                    <span className="text-base mt-0.5 flex-shrink-0">{tipoInfo.icon}</span>
+                    <div className="min-w-0">
+                      <p className="text-xs font-semibold text-indigo-700 mb-0.5">{tipoInfo.label}</p>
+                      <p className="text-sm text-gray-800">{n.mensagem}</p>
+                      {n.link && (
+                        <a href={n.link} className="text-xs text-blue-600 hover:underline mt-0.5 inline-block">
+                          Ver →
+                        </a>
+                      )}
+                      <p className="text-xs text-gray-400 mt-0.5">{formatDate(n.criado_em)}</p>
+                    </div>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+
+      {/* Seção: Renovações de Contrato */}
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="px-4 sm:px-5 py-3 bg-gray-50 border-b border-gray-100">
+          <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+            Renovações de contrato {unreadContracts.length > 0 && `(${unreadContracts.length} não lidas)`}
+          </span>
         </div>
-      )}
+
+        {allContracts.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <svg className="h-10 w-10 text-gray-300 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+            </svg>
+            <p className="text-gray-500 font-medium text-sm">Nenhuma renovação pendente</p>
+            <p className="text-gray-400 text-xs mt-1">O job diário cria alertas para contratos vencendo em ≤90 dias.</p>
+          </div>
+        ) : (
+          <>
+            {unreadContracts.length > 0 && (
+              <div>
+                <div className="px-4 sm:px-5 py-2 bg-gray-50/50 border-b border-gray-100">
+                  <span className="text-xs font-medium text-gray-400">Não lidas ({unreadContracts.length})</span>
+                </div>
+                <ul className="divide-y divide-gray-100">
+                  {unreadContracts.map((n) => {
+                    const cfg = URGENCY_CONFIG[n.urgency]
+                    return (
+                      <li key={n.id} className={`flex items-center justify-between px-4 sm:px-5 py-4 ${cfg.bg}`}>
+                        <div className="flex items-start gap-3 min-w-0">
+                          <span className="text-lg mt-0.5 flex-shrink-0">{cfg.icon}</span>
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-gray-900">
+                              {n.professional_name}
+                              {n.client_name && <span className="font-normal text-gray-500"> — {n.client_name}</span>}
+                            </p>
+                            <p className={`text-xs mt-0.5 ${cfg.text}`}>
+                              Vence em {n.days_until_expiry} dias
+                              {n.renewal_deadline && ` (${formatDate(n.renewal_deadline)})`}
+                            </p>
+                          </div>
+                        </div>
+                        <form action={markAsRead.bind(null, n.id)} className="ml-4 flex-shrink-0">
+                          <button
+                            type="submit"
+                            className="text-xs text-gray-500 hover:text-gray-900 border border-gray-300 rounded px-2.5 py-1 bg-white hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          >
+                            Marcar como lida
+                          </button>
+                        </form>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </div>
+            )}
+            {readContracts.length > 0 && (
+              <div>
+                <div className="px-4 sm:px-5 py-2 bg-gray-50/50 border-b border-gray-100">
+                  <span className="text-xs font-medium text-gray-400">Lidas ({readContracts.length})</span>
+                </div>
+                <ul className="divide-y divide-gray-100">
+                  {readContracts.map((n) => {
+                    const cfg = URGENCY_CONFIG[n.urgency]
+                    return (
+                      <li key={n.id} className="flex items-center gap-3 px-4 sm:px-5 py-4 opacity-50">
+                        <span className="text-base flex-shrink-0">{cfg.icon}</span>
+                        <div className="min-w-0">
+                          <p className="text-sm text-gray-700">
+                            {n.professional_name}
+                            {n.client_name && <span className="text-gray-400"> — {n.client_name}</span>}
+                          </p>
+                          <p className="text-xs text-gray-400 mt-0.5">Lida em {formatDate(n.read_at)}</p>
+                        </div>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </div>
+            )}
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/layout/notification-bell.tsx
+++ b/src/components/layout/notification-bell.tsx
@@ -4,12 +4,20 @@ import Link from 'next/link'
 export async function NotificationBell() {
   const supabase = await createClient()
 
-  const { count } = await supabase
-    .from('contract_notifications')
-    .select('*', { count: 'exact', head: true })
-    .is('read_at', null)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabaseAny = supabase as any
+  const [{ count: countContratos }, { count: countNotif }] = await Promise.all([
+    supabase
+      .from('contract_notifications')
+      .select('*', { count: 'exact', head: true })
+      .is('read_at', null),
+    supabaseAny
+      .from('notifications')
+      .select('*', { count: 'exact', head: true })
+      .eq('lida', false),
+  ])
 
-  const unread = count ?? 0
+  const unread = (countContratos ?? 0) + (countNotif ?? 0)
 
   return (
     <Link

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,23 @@
+'use server'
+
+import { createAdminClient } from '@/lib/supabase/admin'
+
+export async function insertNotification({
+  user_id,
+  tipo,
+  mensagem,
+  link,
+}: {
+  user_id: string
+  tipo: string
+  mensagem: string
+  link?: string
+}) {
+  try {
+    const admin = createAdminClient()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (admin as any).from('notifications').insert({ user_id, tipo, mensagem, link })
+  } catch {
+    // best-effort: não bloqueia a action principal
+  }
+}


### PR DESCRIPTION
## ⚠️ PRÉ-REQUISITO: Aplicar migration SQL antes do deploy

Executar no Supabase SQL Editor (arquivo incluído no PR):
```
scripts/migrations/20260414_create_notifications.sql
```
Cria a tabela `notifications` com RLS. Sem isso, o badge do sino retorna 0 mas não quebra.

---

## O que foi feito

- **`src/lib/notifications.ts`** — novo helper `insertNotification()` via service_role (best-effort)
- **`src/actions/professional-notes.ts`** — `createNoteAction` detecta `@menção` e insere notificação para o usuário mencionado
- **`gerenciar-usuarios/actions.ts`** — `createUserAction` e `deactivateUserAction` notificam todos os admins
- **`notificacoes/page.tsx`** — duas seções: "Sistema" (nova tabela) + "Renovações" (contract_notifications) + filtro por tipo via searchParams + botão "Marcar sistema como lidas"
- **`notification-bell.tsx`** — badge soma ambas as tabelas

## Como testar (após migration aplicada)

1. Escrever nota com `@[nome_colega]` → colega vê notificação em /notificacoes
2. Criar convite → admins recebem notificação `user_invited`
3. Desativar usuário → admins recebem notificação `user_deactivated`
4. Badge no header reflete total não lido das duas tabelas
5. Filtro por tipo funciona
6. "Marcar sistema como lidas" zera as não lidas de sistema

## Relacionado

MELHORIA-011 / TICKET-011

🤖 Generated with Claude Code