### PR TITLE
fix(MELHORIA-012): remover número duplicado nos cards de Renovações

### DIFF
--- a/src/app/(dashboard)/renovacoes/page.tsx
+++ b/src/app/(dashboard)/renovacoes/page.tsx
@@ -70,9 +70,8 @@ function SummaryCard({
   return (
     <div className={`rounded-lg border ${config.bgLight} p-4 hover:shadow-md transition-shadow`}>
       <div className="flex items-center gap-3">
-        <div className={`rounded-full ${config.bg} p-3`}>
-          <span className={`text-lg font-bold ${config.textColor}`}>{count}</span>
-        </div>
+        {/* Indicador de urgência — cor sem número */}
+        <div className={`rounded-full ${config.bg} w-11 h-11 flex-shrink-0`} />
         <div>
           <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
             {label}


### PR DESCRIPTION
## O que foi feito

- Remove `{count}` do interior do círculo colorido em `SummaryCard`
- Círculo passa a ser indicador de urgência por cor (sem número)
- Número aparece apenas uma vez como `text-2xl` abaixo do label
- Mudança cirúrgica: 3 linhas alteradas, layout e cores idênticos

## Como testar

1. Acessar `/renovacoes`
2. Verificar que os 4 cards mostram o número apenas uma vez (abaixo do label)
3. Verificar que o círculo colorido permanece visível com tamanho correto

## Relacionado

MELHORIA-012 / TICKET-012

🤖 Generated with Claude Code