### PR TITLE
feat(MELHORIA-013): visualização calendário anual + shelf lateral em …

### DIFF
--- a/src/app/(dashboard)/ferias/page.tsx
+++ b/src/app/(dashboard)/ferias/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server'
 import { VacationTable } from '@/components/profissionais/ferias/vacation-table'
+import { CalendarView } from '@/components/profissionais/ferias/calendar-view'
 import { Suspense } from 'react'
 import Link from 'next/link'
 import { VacationFilters } from './filters'
@@ -13,6 +14,8 @@ interface SearchParams {
   page?: string
   sortBy?: string
   sortDir?: string
+  view?: string
+  year?: string
 }
 
 interface FeriasPageProps {
@@ -21,6 +24,8 @@ interface FeriasPageProps {
 
 export default async function FeriasPage({ searchParams }: FeriasPageProps) {
   const params = await searchParams
+  const view = params.view === 'calendar' ? 'calendar' : 'list'
+  const year = parseInt(params.year ?? String(new Date().getFullYear()), 10)
   const search = params.q?.trim() ?? ''
   const clientArea = params.client_area ?? ''
   const page = Math.max(1, parseInt(params.page ?? '1', 10))
@@ -62,6 +67,27 @@ export default async function FeriasPage({ searchParams }: FeriasPageProps) {
   const totalPages = Math.ceil((count ?? 0) / PAGE_SIZE)
   const totalCount = count ?? 0
 
+  // Query para o calendário: todas as férias que se sobrepõem ao ano selecionado
+  let calendarVacations: typeof vacations = []
+  if (view === 'calendar') {
+    const yearStart = `${year}-01-01`
+    const yearEnd = `${year}-12-31`
+    const { data: calData } = await supabase
+      .from('vacations')
+      .select('id, professional_name, vacation_start, vacation_end, acquisition_start, acquisition_end, total_days, days_balance, leadership, client_area, created_at')
+      .lte('vacation_start', yearEnd)
+      .or(`vacation_end.gte.${yearStart},vacation_start.gte.${yearStart}`)
+      .order('professional_name', { ascending: true })
+    calendarVacations = calData ?? []
+  }
+
+  const buildYearUrl = (y: number) => {
+    const p = new URLSearchParams()
+    p.set('view', 'calendar')
+    p.set('year', String(y))
+    return `/ferias?${p.toString()}`
+  }
+
   const buildUrl = (newPage: number) => {
     const p = new URLSearchParams()
     if (search) p.set('q', search)
@@ -95,77 +121,110 @@ export default async function FeriasPage({ searchParams }: FeriasPageProps) {
               : 'Nenhuma férias cadastrada'}
           </p>
         </div>
-        {userCanWrite && (
-          <Link
-            href="/ferias/novo"
-            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-            </svg>
-            Novo Registro
-          </Link>
-        )}
-      </div>
+        <div className="flex items-center gap-3">
+          {/* Toggle Lista / Calendário */}
+          <div className="flex items-center bg-gray-100 rounded-lg p-1 gap-0.5">
+            <Link
+              href="/ferias"
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-all ${view === 'list' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+              </svg>
+              Lista
+            </Link>
+            <Link
+              href={`/ferias?view=calendar&year=${year}`}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-all ${view === 'calendar' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              Calendário
+            </Link>
+          </div>
 
-      {/* Card com filtros + tabela */}
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-
-        {/* Filtros */}
-        <div className="px-5 py-4 border-b border-gray-100">
-          <Suspense>
-            <VacationFilters />
-          </Suspense>
+          {userCanWrite && (
+            <Link
+              href="/ferias/novo"
+              className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+              </svg>
+              Novo Registro
+            </Link>
+          )}
         </div>
-
-        {/* Erro */}
-        {error && (
-          <div className="px-5 py-4 text-sm text-red-600 bg-red-50 border-b border-red-100">
-            Erro ao carregar férias: {error.message}
-          </div>
-        )}
-
-        {/* Tabela */}
-        <VacationTable
-          vacations={vacations ?? []}
-          sortBy={sortBy}
-          sortDir={sortDir}
-          buildSortUrl={buildSortUrl}
-        />
-
-        {/* Paginação */}
-        {totalPages > 1 && (
-          <div className="flex items-center justify-between px-5 py-4 border-t border-gray-100 bg-gray-50">
-            <p className="text-sm text-gray-500">
-              Página {page} de {totalPages}
-            </p>
-            <div className="flex gap-2">
-              {page > 1 && (
-                <Link
-                  href={buildUrl(page - 1)}
-                  className="inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                >
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-                  </svg>
-                  Anterior
-                </Link>
-              )}
-              {page < totalPages && (
-                <Link
-                  href={buildUrl(page + 1)}
-                  className="inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                >
-                  Próxima
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                  </svg>
-                </Link>
-              )}
-            </div>
-          </div>
-        )}
       </div>
+
+      {view === 'calendar' ? (
+        /* ── Visualização Calendário ── */
+        <CalendarView
+          vacations={calendarVacations ?? []}
+          year={year}
+          buildYearUrl={buildYearUrl}
+        />
+      ) : (
+        /* ── Visualização Lista ── */
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+
+          {/* Filtros */}
+          <div className="px-5 py-4 border-b border-gray-100">
+            <Suspense>
+              <VacationFilters />
+            </Suspense>
+          </div>
+
+          {/* Erro */}
+          {error && (
+            <div className="px-5 py-4 text-sm text-red-600 bg-red-50 border-b border-red-100">
+              Erro ao carregar férias: {error.message}
+            </div>
+          )}
+
+          {/* Tabela */}
+          <VacationTable
+            vacations={vacations ?? []}
+            sortBy={sortBy}
+            sortDir={sortDir}
+            buildSortUrl={buildSortUrl}
+          />
+
+          {/* Paginação */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between px-5 py-4 border-t border-gray-100 bg-gray-50">
+              <p className="text-sm text-gray-500">
+                Página {page} de {totalPages}
+              </p>
+              <div className="flex gap-2">
+                {page > 1 && (
+                  <Link
+                    href={buildUrl(page - 1)}
+                    className="inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+                    </svg>
+                    Anterior
+                  </Link>
+                )}
+                {page < totalPages && (
+                  <Link
+                    href={buildUrl(page + 1)}
+                    className="inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    Próxima
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </Link>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/profissionais/ferias/calendar-view.tsx
+++ b/src/components/profissionais/ferias/calendar-view.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { VacationShelf, type VacationShelfData } from './vacation-shelf'
+
+const MONTH_NAMES = ['JAN','FEV','MAR','ABR','MAI','JUN','JUL','AGO','SET','OUT','NOV','DEZ']
+
+interface CalendarVacation extends VacationShelfData {
+  vacation_start: string | null
+  vacation_end: string | null
+}
+
+interface CalendarViewProps {
+  vacations: CalendarVacation[]
+  year: number
+  buildYearUrl: (year: number) => string
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(n => n[0].toUpperCase())
+    .join('')
+}
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate()
+}
+
+function isRealizado(vacationStart: string | null): boolean {
+  if (!vacationStart) return false
+  return new Date(vacationStart) < new Date()
+}
+
+/** Calcula quantos dias da férias caem no mês especificado (0-indexed). */
+function daysInMonthForVacation(
+  vacationStart: string,
+  vacationEnd: string,
+  year: number,
+  month: number
+): number {
+  const firstDay = new Date(year, month, 1)
+  const lastDay = new Date(year, month, daysInMonth(year, month))
+  const ini = new Date(vacationStart) > firstDay ? new Date(vacationStart) : firstDay
+  const fim = new Date(vacationEnd) < lastDay ? new Date(vacationEnd) : lastDay
+  if (ini > fim) return 0
+  return Math.round((fim.getTime() - ini.getTime()) / 86400000) + 1
+}
+
+/** Retorna os chips que devem aparecer em cada mês. */
+function buildMonthData(
+  vacations: CalendarVacation[],
+  year: number
+): Array<Array<{ vacation: CalendarVacation; days: number }>> {
+  return Array.from({ length: 12 }, (_, month) => {
+    const firstDay = new Date(year, month, 1)
+    const lastDay = new Date(year, month, daysInMonth(year, month))
+
+    return vacations
+      .filter(v => {
+        if (!v.vacation_start) return false
+        const start = new Date(v.vacation_start)
+        const end = v.vacation_end ? new Date(v.vacation_end) : start
+        return start <= lastDay && end >= firstDay
+      })
+      .map(v => ({
+        vacation: v,
+        days: daysInMonthForVacation(
+          v.vacation_start!,
+          v.vacation_end ?? v.vacation_start!,
+          year,
+          month
+        ),
+      }))
+  })
+}
+
+export function CalendarView({ vacations, year, buildYearUrl }: CalendarViewProps) {
+  const [selectedVacation, setSelectedVacation] = useState<CalendarVacation | null>(null)
+  const monthData = buildMonthData(vacations, year)
+
+  return (
+    <>
+      {/* Navegação de ano */}
+      <div className="flex items-center justify-center gap-5 py-4">
+        <Link
+          href={buildYearUrl(year - 1)}
+          className="flex items-center justify-center w-9 h-9 rounded-lg border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 transition-colors"
+          aria-label={`Ano ${year - 1}`}
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+        </Link>
+        <span className="text-2xl font-bold text-gray-900 min-w-[80px] text-center">{year}</span>
+        <Link
+          href={buildYearUrl(year + 1)}
+          className="flex items-center justify-center w-9 h-9 rounded-lg border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 transition-colors"
+          aria-label={`Ano ${year + 1}`}
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </Link>
+      </div>
+
+      {/* Grade 4×3 de meses */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {MONTH_NAMES.map((monthName, month) => {
+          const chips = monthData[month]
+          return (
+            <div
+              key={month}
+              className="bg-white rounded-xl border border-gray-200 overflow-hidden hover:shadow-md transition-shadow"
+            >
+              {/* Header roxo */}
+              <div className="bg-indigo-600 px-3.5 py-2">
+                <span className="text-xs font-bold tracking-widest text-white">{monthName}</span>
+              </div>
+
+              {/* Body com chips */}
+              <div className="px-3 py-2.5 min-h-[80px] flex flex-col gap-1.5">
+                {chips.length === 0 ? (
+                  <p className="text-xs text-gray-300 italic py-1">Nenhuma férias</p>
+                ) : (
+                  chips.map(({ vacation, days }) => {
+                    const realizado = isRealizado(vacation.vacation_start)
+                    return (
+                      <button
+                        key={`${vacation.id}-${month}`}
+                        onClick={() => setSelectedVacation(vacation)}
+                        className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium w-full text-left transition-all ${
+                          realizado
+                            ? 'bg-green-50 border border-green-200 text-green-800 hover:bg-green-100'
+                            : 'bg-indigo-50 border border-indigo-200 text-indigo-800 hover:bg-indigo-100'
+                        }`}
+                      >
+                        {/* Avatar */}
+                        <span className={`flex-shrink-0 flex items-center justify-center w-5 h-5 rounded-full text-white text-[9px] font-bold ${realizado ? 'bg-green-600' : 'bg-indigo-600'}`}>
+                          {getInitials(vacation.professional_name)}
+                        </span>
+                        {/* Nome truncado */}
+                        <span className="flex-1 truncate min-w-0">
+                          {vacation.professional_name.split(' ')[0]}
+                        </span>
+                        {/* Dias badge */}
+                        <span className={`flex-shrink-0 rounded-full px-1.5 py-px text-white text-[10px] font-semibold ${realizado ? 'bg-green-600' : 'bg-indigo-600'}`}>
+                          {days}
+                        </span>
+                      </button>
+                    )
+                  })
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Shelf lateral */}
+      <VacationShelf
+        vacation={selectedVacation}
+        onClose={() => setSelectedVacation(null)}
+      />
+    </>
+  )
+}

--- a/src/components/profissionais/ferias/vacation-shelf.tsx
+++ b/src/components/profissionais/ferias/vacation-shelf.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { formatDate } from '@/lib/utils/formatting'
+
+export interface VacationShelfData {
+  id: string
+  professional_name: string
+  vacation_start: string | null
+  vacation_end: string | null
+  acquisition_start: string | null
+  acquisition_end: string | null
+  total_days: number | null
+  days_balance: number | null
+  leadership: string | null
+  client_area: string | null
+}
+
+interface VacationShelfProps {
+  vacation: VacationShelfData | null
+  onClose: () => void
+}
+
+function deriveStatus(vacationStart: string | null): { label: string; color: string } {
+  if (!vacationStart) return { label: '—', color: 'bg-gray-100 text-gray-600' }
+  return new Date(vacationStart) < new Date()
+    ? { label: 'Realizado', color: 'bg-green-100 text-green-700' }
+    : { label: 'Agendado', color: 'bg-blue-100 text-blue-700' }
+}
+
+export function VacationShelf({ vacation, onClose }: VacationShelfProps) {
+  const open = vacation !== null
+
+  // Fechar com Escape
+  useEffect(() => {
+    if (!open) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, onClose])
+
+  const status = vacation ? deriveStatus(vacation.vacation_start) : null
+  const progressPct = vacation && vacation.total_days && vacation.days_balance != null
+    ? Math.min(100, Math.round(((vacation.total_days - vacation.days_balance) / vacation.total_days) * 100))
+    : null
+
+  return (
+    <>
+      {/* Overlay */}
+      <div
+        className={`fixed inset-0 bg-black/35 z-40 transition-opacity duration-200 ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Shelf */}
+      <div
+        className={`fixed top-0 right-0 bottom-0 w-full sm:w-[480px] bg-white z-50 flex flex-col shadow-2xl transition-transform duration-[250ms] ease-[cubic-bezier(.4,0,.2,1)] ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Detalhes do registro de férias"
+      >
+        {vacation && (
+          <>
+            {/* Header */}
+            <div className="flex items-start justify-between px-6 py-5 border-b border-gray-100 flex-shrink-0">
+              <div>
+                <h2 className="text-xl font-bold text-gray-900">{vacation.professional_name}</h2>
+                <p className="text-sm text-gray-500 mt-0.5">Detalhes do registro de férias</p>
+              </div>
+              <div className="flex items-center gap-2 ml-4">
+                <Link
+                  href={`/ferias/${vacation.id}/editar`}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
+                  </svg>
+                  Editar
+                </Link>
+                <button
+                  onClick={onClose}
+                  className="rounded-lg border border-gray-200 bg-white p-1.5 text-gray-500 hover:bg-gray-50 transition-colors"
+                  aria-label="Fechar painel"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            {/* Body */}
+            <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+              {/* Identificação */}
+              <section>
+                <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Identificação</h3>
+                <dl className="grid grid-cols-2 gap-x-6 gap-y-3">
+                  <div>
+                    <dt className="text-xs text-gray-500">Nome</dt>
+                    <dd className="text-sm font-medium text-gray-900 mt-0.5">{vacation.professional_name}</dd>
+                  </div>
+                  {vacation.leadership && (
+                    <div>
+                      <dt className="text-xs text-gray-500">Liderança</dt>
+                      <dd className="text-sm font-medium text-gray-900 mt-0.5">{vacation.leadership}</dd>
+                    </div>
+                  )}
+                  {vacation.client_area && (
+                    <div className="col-span-2">
+                      <dt className="text-xs text-gray-500">Área / Cliente</dt>
+                      <dd className="text-sm font-medium text-gray-900 mt-0.5">{vacation.client_area}</dd>
+                    </div>
+                  )}
+                </dl>
+              </section>
+
+              <hr className="border-gray-100" />
+
+              {/* Período Aquisitivo */}
+              <section>
+                <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Período Aquisitivo</h3>
+                <dl className="grid grid-cols-2 gap-x-6 gap-y-3">
+                  <div>
+                    <dt className="text-xs text-gray-500">Início</dt>
+                    <dd className="text-sm font-medium text-gray-900 mt-0.5">
+                      {vacation.acquisition_start ? formatDate(vacation.acquisition_start) : '—'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Fim</dt>
+                    <dd className="text-sm font-medium text-gray-900 mt-0.5">
+                      {vacation.acquisition_end ? formatDate(vacation.acquisition_end) : '—'}
+                    </dd>
+                  </div>
+                </dl>
+              </section>
+
+              <hr className="border-gray-100" />
+
+              {/* Período de Gozo */}
+              <section>
+                <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Período de Gozo</h3>
+                <dl className="grid grid-cols-2 gap-x-6 gap-y-3">
+                  <div>
+                    <dt className="text-xs text-gray-500">Início das Férias</dt>
+                    <dd className="text-sm font-medium text-gray-900 mt-0.5">
+                      {vacation.vacation_start ? formatDate(vacation.vacation_start) : '—'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Fim das Férias</dt>
+                    <dd className="text-sm font-medium text-gray-900 mt-0.5">
+                      {vacation.vacation_end ? formatDate(vacation.vacation_end) : '—'}
+                    </dd>
+                  </div>
+                  {status && (
+                    <div>
+                      <dt className="text-xs text-gray-500">Status</dt>
+                      <dd className="mt-0.5">
+                        <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${status.color}`}>
+                          {status.label}
+                        </span>
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+              </section>
+
+              <hr className="border-gray-100" />
+
+              {/* Dados Complementares */}
+              <section>
+                <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Dados Complementares</h3>
+                <dl className="grid grid-cols-2 gap-x-6 gap-y-3 mb-4">
+                  <div>
+                    <dt className="text-xs text-gray-500">Total de Dias</dt>
+                    <dd className="text-sm font-medium text-gray-900 mt-0.5">
+                      {vacation.total_days != null ? `${vacation.total_days} dias` : '—'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Saldo de Dias</dt>
+                    <dd className="text-sm font-medium text-gray-900 mt-0.5">
+                      {vacation.days_balance != null ? `${vacation.days_balance} dias` : '—'}
+                    </dd>
+                  </div>
+                </dl>
+
+                {/* Barra de progresso */}
+                {progressPct !== null && (
+                  <div>
+                    <div className="flex justify-between text-xs text-gray-500 mb-1">
+                      <span>Dias utilizados</span>
+                      <span>{progressPct}%</span>
+                    </div>
+                    <div className="w-full bg-gray-100 rounded-full h-2">
+                      <div
+                        className="bg-indigo-500 h-2 rounded-full transition-all duration-300"
+                        style={{ width: `${progressPct}%` }}
+                      />
+                    </div>
+                  </div>
+                )}
+              </section>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
…/ferias

- Adiciona toggle Lista/Calendário no header de /ferias (via searchParams)
- Novo CalendarView: grade 4×3 JAN→DEZ com navegação de ano
- Chips de profissional por mês com dias proporcionais (cruzamento de meses)
- Verde para Realizado, roxo para Agendado
- Novo VacationShelf: painel deslizante (480px) com todos os campos do registro
- Barra de progresso de dias utilizados no shelf
- Fechar shelf com ✕, overlay e ESC
- View padrão permanece Lista (zero regressão)