### PR TITLE
fix(BUG-FERIAS-CALENDAR): remover buildYearUrl como prop Server→Client

### DIFF
--- a/src/app/(dashboard)/ferias/page.tsx
+++ b/src/app/(dashboard)/ferias/page.tsx
@@ -81,13 +81,6 @@ export default async function FeriasPage({ searchParams }: FeriasPageProps) {
     calendarVacations = calData ?? []
   }
 
-  const buildYearUrl = (y: number) => {
-    const p = new URLSearchParams()
-    p.set('view', 'calendar')
-    p.set('year', String(y))
-    return `/ferias?${p.toString()}`
-  }
-
   const buildUrl = (newPage: number) => {
     const p = new URLSearchParams()
     if (search) p.set('q', search)
@@ -163,7 +156,6 @@ export default async function FeriasPage({ searchParams }: FeriasPageProps) {
         <CalendarView
           vacations={calendarVacations ?? []}
           year={year}
-          buildYearUrl={buildYearUrl}
         />
       ) : (
         /* ── Visualização Lista ── */

--- a/src/components/profissionais/ferias/calendar-view.tsx
+++ b/src/components/profissionais/ferias/calendar-view.tsx
@@ -14,7 +14,6 @@ interface CalendarVacation extends VacationShelfData {
 interface CalendarViewProps {
   vacations: CalendarVacation[]
   year: number
-  buildYearUrl: (year: number) => string
 }
 
 function getInitials(name: string): string {
@@ -33,6 +32,10 @@ function daysInMonth(year: number, month: number): number {
 function isRealizado(vacationStart: string | null): boolean {
   if (!vacationStart) return false
   return new Date(vacationStart) < new Date()
+}
+
+function buildYearUrl(year: number): string {
+  return `/ferias?view=calendar&year=${year}`
 }
 
 /** Calcula quantos dias da férias caem no mês especificado (0-indexed). */
@@ -78,7 +81,7 @@ function buildMonthData(
   })
 }
 
-export function CalendarView({ vacations, year, buildYearUrl }: CalendarViewProps) {
+export function CalendarView({ vacations, year }: CalendarViewProps) {
   const [selectedVacation, setSelectedVacation] = useState<CalendarVacation | null>(null)
   const monthData = buildMonthData(vacations, year)
 


### PR DESCRIPTION
## Causa raiz

`buildYearUrl` era uma função definida no Server Component (`ferias/page.tsx`) e passada como prop para `CalendarView` (`'use client'`). No Next.js App Router, funções **não podem ser serializadas** pela boundary Server→Client — isso causa um runtime error que derruba a página inteira em `/ferias?view=calendar`.

## Correção

- Removida a prop `buildYearUrl` da interface `CalendarViewProps`
- Função `buildYearUrl` movida para dentro do `CalendarView` (lógica pura: `/ferias?view=calendar&year=${y}`)
- Removida a função e sua passagem de `ferias/page.tsx`

## Como testar

1. `/ferias` → lista carrega normalmente
2. `/ferias?view=calendar&year=2026` → calendário anual carrega sem erro
3. Clicar nas setas ← → navega entre anos corretamente

🤖 Generated with Claude Code