### PR TITLE
feat(EP-EQUIP-AUTOCOMPLETE): autocomplete de profissional no formulário de equipamento

### DIFF
--- a/scripts/migrations/20260414_add_professional_id_to_equipment.sql
+++ b/scripts/migrations/20260414_add_professional_id_to_equipment.sql
@@ -1,0 +1,15 @@
+-- 1. Adicionar coluna professional_id (nullable)
+ALTER TABLE equipment
+  ADD COLUMN IF NOT EXISTS professional_id UUID
+  REFERENCES professionals(id) ON DELETE SET NULL;
+
+-- 2. Auto-vincular por match exato de nome (case-insensitive)
+UPDATE equipment e
+SET professional_id = p.id
+FROM professionals p
+WHERE lower(trim(e.professional_name)) = lower(trim(p.name))
+  AND e.professional_id IS NULL;
+
+-- 3. Índice para performance
+CREATE INDEX IF NOT EXISTS idx_equipment_professional_id
+  ON equipment(professional_id);

--- a/src/actions/equipment.ts
+++ b/src/actions/equipment.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { createClient } from '@/lib/supabase/server'
-import { requireWriteAccess } from '@/lib/auth-check'
 import { handleActionError } from '@/lib/errors'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
@@ -10,6 +9,7 @@ import { logAudit } from '@/lib/audit'
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface EquipmentFormData {
+  professional_id: string
   professional_name: string
   company?: string
   machine_type?: string
@@ -34,30 +34,26 @@ export async function createEquipment(
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (!user || authError) return { error: 'Não autorizado.' }
 
-  const data: EquipmentFormData = {
-    professional_name: formData.get('professional_name') as string,
-    company: formData.get('company') as string,
-    machine_type: formData.get('machine_type') as string,
-    machine_model: formData.get('machine_model') as string,
-    office_package: formData.get('office_package') as string,
-    software_details: formData.get('software_details') as string,
+  const professionalId = formData.get('professional_id') as string
+  const professionalName = formData.get('professional_name') as string
+
+  if (!professionalId?.trim()) {
+    return { error: 'Selecione um profissional cadastrado.' }
   }
 
-  if (!data.professional_name?.trim()) {
-    return { error: 'Nome do profissional é obrigatório.' }
-  }
-
+  // professional_id adicionado via migration — cast até tipos serem regenerados
   const payload = {
-    professional_name: data.professional_name.trim(),
-    company: data.company?.trim() || null,
-    machine_type: data.machine_type || null,
-    machine_model: data.machine_model?.trim() || null,
-    office_package: data.office_package === 'on' || data.office_package === 'true',
-    software_details: data.software_details?.trim() || null,
+    professional_id: professionalId,
+    professional_name: professionalName?.trim() || '',
+    company: (formData.get('company') as string)?.trim() || null,
+    machine_type: (formData.get('machine_type') as string) || null,
+    machine_model: (formData.get('machine_model') as string)?.trim() || null,
+    office_package: formData.get('office_package') === 'on' || formData.get('office_package') === 'true',
+    software_details: (formData.get('software_details') as string)?.trim() || null,
   }
 
-  const { data: created, error } = await supabase
-    .from('equipment')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: created, error } = await (supabase.from('equipment') as any)
     .insert(payload)
     .select()
     .single()
@@ -91,26 +87,22 @@ export async function updateEquipment(
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (!user || authError) return { error: 'Não autorizado.' }
 
-  const data: EquipmentFormData = {
-    professional_name: formData.get('professional_name') as string,
-    company: formData.get('company') as string,
-    machine_type: formData.get('machine_type') as string,
-    machine_model: formData.get('machine_model') as string,
-    office_package: formData.get('office_package') as string,
-    software_details: formData.get('software_details') as string,
+  const professionalId = formData.get('professional_id') as string
+  const professionalName = formData.get('professional_name') as string
+
+  if (!professionalId?.trim()) {
+    return { error: 'Selecione um profissional cadastrado.' }
   }
 
-  if (!data.professional_name?.trim()) {
-    return { error: 'Nome do profissional é obrigatório.' }
-  }
-
+  // professional_id adicionado via migration — cast até tipos serem regenerados
   const payload = {
-    professional_name: data.professional_name.trim(),
-    company: data.company?.trim() || null,
-    machine_type: data.machine_type || null,
-    machine_model: data.machine_model?.trim() || null,
-    office_package: data.office_package === 'on' || data.office_package === 'true',
-    software_details: data.software_details?.trim() || null,
+    professional_id: professionalId,
+    professional_name: professionalName?.trim() || '',
+    company: (formData.get('company') as string)?.trim() || null,
+    machine_type: (formData.get('machine_type') as string) || null,
+    machine_model: (formData.get('machine_model') as string)?.trim() || null,
+    office_package: formData.get('office_package') === 'on' || formData.get('office_package') === 'true',
+    software_details: (formData.get('software_details') as string)?.trim() || null,
   }
 
   const { data: antes } = await supabase
@@ -119,8 +111,8 @@ export async function updateEquipment(
     .eq('id', id)
     .single()
 
-  const { error } = await supabase
-    .from('equipment')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase.from('equipment') as any)
     .update(payload)
     .eq('id', id)
 

--- a/src/app/(dashboard)/equipamentos/[id]/editar/page.tsx
+++ b/src/app/(dashboard)/equipamentos/[id]/editar/page.tsx
@@ -18,8 +18,8 @@ export default async function EditEquipmentPage({ params }: EditEquipmentPagePro
   const { data: profile } = await supabase.from('profiles').select('role').eq('id', user.id).single()
   if (!canWrite(profile?.role)) redirect('/equipamentos')
 
-  const { data: equipment, error } = await supabase
-    .from('equipment')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: equipment, error } = await (supabase.from('equipment') as any)
     .select('*')
     .eq('id', id)
     .single()
@@ -27,6 +27,18 @@ export default async function EditEquipmentPage({ params }: EditEquipmentPagePro
   if (error || !equipment) {
     notFound()
   }
+
+  const { data: professionals } = await supabase
+    .from('professionals')
+    .select('id, name, clients(name)')
+    .eq('status', 'Ativo')
+    .order('name')
+
+  const profOptions = (professionals ?? []).map((p: { id: string; name: string; clients: { name: string } | null }) => ({
+    id: p.id,
+    name: p.name,
+    clientName: (p.clients as { name: string } | null)?.name ?? '',
+  }))
 
   const boundUpdateEquipment = (prevState: ActionResult, formData: FormData) => updateEquipment(id, prevState, formData)
 
@@ -55,6 +67,7 @@ export default async function EditEquipmentPage({ params }: EditEquipmentPagePro
       <EquipmentForm
         action={boundUpdateEquipment}
         defaultValues={equipment}
+        professionals={profOptions}
         submitLabel="Salvar Alterações"
         cancelHref={`/equipamentos/${id}`}
       />

--- a/src/app/(dashboard)/equipamentos/[id]/page.tsx
+++ b/src/app/(dashboard)/equipamentos/[id]/page.tsx
@@ -103,7 +103,7 @@ export default async function EquipmentDetailPage({ params }: EquipmentDetailPag
           >
             <div className="grid grid-cols-2 gap-x-8 gap-y-5">
               <InfoField label="Profissional" value={equipment.professional_name} />
-              <InfoField label="Empresa" value={equipment.company} />
+              <InfoField label="Cliente" value={equipment.company} />
             </div>
           </SectionCard>
 

--- a/src/app/(dashboard)/equipamentos/novo/page.tsx
+++ b/src/app/(dashboard)/equipamentos/novo/page.tsx
@@ -11,6 +11,19 @@ export default async function NovoEquipamentoPage() {
   if (!user) redirect('/login')
   const { data: profile } = await supabase.from('profiles').select('role').eq('id', user.id).single()
   if (!canWrite(profile?.role)) redirect('/equipamentos')
+
+  const { data: professionals } = await supabase
+    .from('professionals')
+    .select('id, name, clients(name)')
+    .eq('status', 'Ativo')
+    .order('name')
+
+  const profOptions = (professionals ?? []).map(p => ({
+    id: p.id,
+    name: p.name,
+    clientName: (p.clients as { name: string } | null)?.name ?? '',
+  }))
+
   return (
     <div className="space-y-6 max-w-3xl">
       {/* Header */}
@@ -30,6 +43,7 @@ export default async function NovoEquipamentoPage() {
 
       <EquipmentForm
         action={createEquipment}
+        professionals={profOptions}
         submitLabel="Criar Equipamento"
         cancelHref="/equipamentos"
       />

--- a/src/app/(dashboard)/profissionais/[id]/page.tsx
+++ b/src/app/(dashboard)/profissionais/[id]/page.tsx
@@ -59,12 +59,12 @@ export default async function ProfissionalDetailPage({ params }: ProfissionalDet
     notFound()
   }
 
-  // Busca equipamento pelo nome (FK por nome no schema atual)
-  const { data: equipment } = await supabase
-    .from('equipment')
-    .select('*')
-    .eq('professional_name', professional.name)
-    .maybeSingle()
+  // Busca equipamentos via professional_id (FK adicionada via migration)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: equipmentList } = await (supabase.from('equipment') as any)
+    .select('id, machine_type, machine_model, office_package, software_details, company')
+    .eq('professional_id', professional.id)
+    .order('created_at', { ascending: false })
 
   // Busca férias pelo nome
   const { data: vacations } = await supabase
@@ -211,9 +211,10 @@ export default async function ProfissionalDetailPage({ params }: ProfissionalDet
         </div>
       )}
 
+      {/* eslint-disable @typescript-eslint/no-explicit-any */}
       <ProfessionalTabs
         professional={professional as unknown as any}
-        equipment={equipment as unknown as any}
+        equipment={(equipmentList ?? []) as unknown as any}
         vacations={(vacations ?? []) as unknown as any}
         notes={notes}
         canReadNotes={canReadNotes}

--- a/src/components/profissionais/equipment-form.tsx
+++ b/src/components/profissionais/equipment-form.tsx
@@ -1,14 +1,24 @@
 'use client'
 
+import { useState, useRef, useEffect } from 'react'
 import { useActionState } from 'react'
 import { type ActionResult } from '@/actions/equipment'
 import { Database } from '@/lib/types/database'
 
-type Equipment = Database['public']['Tables']['equipment']['Row']
+type EquipmentRow = Database['public']['Tables']['equipment']['Row']
+// professional_id será adicionado via migration — extendido aqui até tipos serem regenerados
+type Equipment = EquipmentRow & { professional_id?: string | null }
+
+interface ProfOption {
+  id: string
+  name: string
+  clientName: string
+}
 
 interface EquipmentFormProps {
   action: (prevState: ActionResult, formData: FormData) => Promise<ActionResult>
   defaultValues?: Partial<Equipment>
+  professionals: ProfOption[]
   submitLabel?: string
   cancelHref?: string
 }
@@ -21,41 +31,13 @@ const MACHINE_TYPE_OPTIONS = [
   { value: 'Outro', label: 'Outro' },
 ]
 
-function FormField({
-  label,
-  name,
-  type = 'text',
-  defaultValue,
-  required,
-  placeholder,
-  children,
-}: {
-  label: string
-  name: string
-  type?: string
-  defaultValue?: string | number | null
-  required?: boolean
-  placeholder?: string
-  children?: React.ReactNode
-}) {
-  return (
-    <div className="space-y-1.5">
-      <label htmlFor={name} className="block text-xs font-medium text-gray-600">
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
-      {children ?? (
-        <input
-          id={name}
-          name={name}
-          type={type}
-          defaultValue={defaultValue ?? ''}
-          required={required}
-          placeholder={placeholder}
-          className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100 transition-colors"
-        />
-      )}
-    </div>
-  )
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(n => n[0].toUpperCase())
+    .join('')
 }
 
 function SelectField({
@@ -149,9 +131,153 @@ function TextAreaField({
   )
 }
 
+function ProfessionalAutocomplete({
+  professionals,
+  defaultProfessionalId,
+  defaultProfessionalName,
+}: {
+  professionals: ProfOption[]
+  defaultProfessionalId?: string | null
+  defaultProfessionalName?: string | null
+}) {
+  const [selected, setSelected] = useState<ProfOption | null>(() => {
+    if (defaultProfessionalId) {
+      return professionals.find(p => p.id === defaultProfessionalId) ?? null
+    }
+    return null
+  })
+  const [query, setQuery] = useState(
+    !defaultProfessionalId && defaultProfessionalName ? defaultProfessionalName : ''
+  )
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const isOldRecord = !defaultProfessionalId && !!defaultProfessionalName
+
+  const filtered = query.trim()
+    ? professionals.filter(p =>
+        p.name.toLowerCase().includes(query.toLowerCase()) ||
+        p.clientName.toLowerCase().includes(query.toLowerCase())
+      )
+    : professionals
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [])
+
+  return (
+    <div className="md:col-span-2 space-y-4">
+      {/* Aviso para registros antigos sem FK */}
+      {isOldRecord && !selected && (
+        <div className="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 flex items-start gap-2.5">
+          <svg className="h-4 w-4 text-yellow-600 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+          </svg>
+          <p className="text-xs text-yellow-800">
+            Este registro não tem profissional vinculado. Selecione um profissional na lista abaixo para associar corretamente.
+          </p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Campo Profissional */}
+        <div className="space-y-1.5" ref={containerRef}>
+          <label className="block text-xs font-medium text-gray-600">
+            Nome do Profissional <span className="text-red-500">*</span>
+          </label>
+
+          {selected ? (
+            /* Badge selecionado */
+            <div className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2">
+              <span className="flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-full bg-indigo-600 text-white text-xs font-bold">
+                {getInitials(selected.name)}
+              </span>
+              <span className="flex-1 text-sm font-medium text-indigo-900 truncate">{selected.name}</span>
+              <button
+                type="button"
+                onClick={() => { setSelected(null); setQuery('') }}
+                className="text-xs text-indigo-600 hover:text-indigo-800 flex-shrink-0 transition-colors"
+              >
+                Trocar
+              </button>
+              <input type="hidden" name="professional_id" value={selected.id} />
+              <input type="hidden" name="professional_name" value={selected.name} />
+              <input type="hidden" name="company" value={selected.clientName} />
+            </div>
+          ) : (
+            /* Input de busca */
+            <div className="relative">
+              <div className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
+                <svg className="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+                </svg>
+              </div>
+              <input
+                type="text"
+                value={query}
+                onChange={e => { setQuery(e.target.value); setOpen(true) }}
+                onFocus={() => setOpen(true)}
+                placeholder="Buscar profissional..."
+                className="w-full rounded-lg border border-gray-200 bg-white pl-9 pr-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100 transition-colors"
+              />
+              {open && filtered.length > 0 && (
+                <ul className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg max-h-56 overflow-auto">
+                  {filtered.map(p => (
+                    <li key={p.id}>
+                      <button
+                        type="button"
+                        onMouseDown={() => { setSelected(p); setOpen(false); setQuery('') }}
+                        className="flex items-center gap-2.5 w-full px-3 py-2.5 text-left hover:bg-indigo-50 transition-colors"
+                      >
+                        <span className="flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-full bg-indigo-600 text-white text-xs font-bold">
+                          {getInitials(p.name)}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-gray-900 truncate">{p.name}</p>
+                          {p.clientName && (
+                            <p className="text-xs text-gray-500 truncate">{p.clientName}</p>
+                          )}
+                        </div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {open && filtered.length === 0 && query.trim() && (
+                <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg px-3 py-3 text-sm text-gray-400 text-center">
+                  Nenhum profissional encontrado
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Campo Cliente (read-only) */}
+        <div className="space-y-1.5">
+          <label className="block text-xs font-medium text-gray-600">Cliente</label>
+          <input
+            type="text"
+            value={selected?.clientName ?? ''}
+            readOnly
+            placeholder="Preenchido ao selecionar o profissional"
+            className="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700 placeholder:text-gray-400 cursor-not-allowed"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function EquipmentForm({
   action,
   defaultValues,
+  professionals,
   submitLabel = 'Salvar',
   cancelHref = '/equipamentos',
 }: EquipmentFormProps) {
@@ -168,20 +294,10 @@ export function EquipmentForm({
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
         <h2 className="text-sm font-semibold text-gray-700 mb-5">Identificação</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="md:col-span-2">
-            <FormField
-              label="Nome do Profissional"
-              name="professional_name"
-              required
-              defaultValue={defaultValues?.professional_name}
-              placeholder="Ex: João da Silva"
-            />
-          </div>
-          <FormField
-            label="Empresa"
-            name="company"
-            defaultValue={defaultValues?.company}
-            placeholder="Ex: Acme Corp"
+          <ProfessionalAutocomplete
+            professionals={professionals}
+            defaultProfessionalId={defaultValues?.professional_id}
+            defaultProfessionalName={defaultValues?.professional_name}
           />
         </div>
       </div>
@@ -196,12 +312,19 @@ export function EquipmentForm({
             placeholder="Selecione um tipo..."
             options={MACHINE_TYPE_OPTIONS}
           />
-          <FormField
-            label="Modelo da Máquina"
-            name="machine_model"
-            defaultValue={defaultValues?.machine_model}
-            placeholder="Ex: MacBook Pro 14"
-          />
+          <div className="space-y-1.5">
+            <label htmlFor="machine_model" className="block text-xs font-medium text-gray-600">
+              Modelo da Máquina
+            </label>
+            <input
+              id="machine_model"
+              name="machine_model"
+              type="text"
+              defaultValue={defaultValues?.machine_model ?? ''}
+              placeholder="Ex: MacBook Pro 14"
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100 transition-colors"
+            />
+          </div>
           <div className="md:col-span-2">
             <CheckboxField
               label="Pacote Office instalado"

--- a/src/components/profissionais/professional-tabs.tsx
+++ b/src/components/profissionais/professional-tabs.tsx
@@ -43,6 +43,8 @@ interface Equipment {
   software_details?: string | null
 }
 
+type EquipmentList = Equipment[]
+
 interface Vacation {
   id: string
   acquisition_start: string | null
@@ -64,7 +66,7 @@ interface Note {
 
 interface ProfessionalTabsProps {
   professional: Professional
-  equipment: Equipment | null
+  equipment: EquipmentList
   vacations: Vacation[]
   notes: Note[]
   canReadNotes: boolean
@@ -118,7 +120,7 @@ function DadosTab({
   renewalStyle,
 }: {
   professional: Professional
-  equipment: Equipment | null
+  equipment: EquipmentList
   vacations: Vacation[]
   currentRole: string
   renewalStyle: { bg: string; label: string }
@@ -278,25 +280,35 @@ function DadosTab({
               </svg>
             }
           >
-            {!equipment ? (
+            {equipment.length === 0 ? (
               <p className="text-sm text-gray-400 text-center py-3">Nenhum equipamento vinculado.</p>
             ) : (
-              <div className="space-y-4">
-                <InfoField label="Empresa" value={equipment.company} />
-                <InfoField label="Modelo" value={equipment.machine_model} />
-                <InfoField label="Tipo" value={equipment.machine_type} />
-                <InfoField
-                  label="Pacote Office"
-                  value={
-                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${equipment.office_package ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
-                      {equipment.office_package ? 'Sim' : 'Não'}
-                    </span>
-                  }
-                />
-                {equipment.software_details && (
-                  <InfoField label="Softwares" value={equipment.software_details} />
-                )}
-              </div>
+              <ul className="divide-y divide-gray-100 -mx-5">
+                {equipment.map(eq => (
+                  <li key={eq.id} className="px-5 py-3 hover:bg-gray-50 transition-colors">
+                    <a href={`/equipamentos/${eq.id}`} className="flex items-center justify-between gap-3 group">
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-800 truncate">
+                          {eq.machine_model ?? '—'} · {eq.machine_type ?? '—'}
+                        </p>
+                        {eq.company && (
+                          <p className="text-xs text-gray-500 truncate">{eq.company}</p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        {eq.office_package && (
+                          <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-green-100 text-green-700">
+                            Office
+                          </span>
+                        )}
+                        <svg className="h-4 w-4 text-gray-400 group-hover:text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                        </svg>
+                      </div>
+                    </a>
+                  </li>
+                ))}
+              </ul>
             )}
           </SectionCard>
 


### PR DESCRIPTION
## O que foi feito

- Campo Nome do Profissional vira autocomplete — busca apenas profissionais ativos cadastrados no sistema
- Badge com iniciais + nome ao selecionar; botão "Trocar" para desfazer seleção
- Campo Empresa renomeado para **Cliente**, preenchido automaticamente (read-only) via FK `professionals → clients`
- FK `professional_id` adicionada à tabela `equipment` via migration inclusa no PR
- Registros antigos sem `professional_id` exibem aviso amarelo no formulário de edição
- Página do profissional agora exibe **lista** de equipamentos vinculados via `professional_id` (antes era item único por nome)
- Label "Empresa" → "Cliente" no formulário e na tela de detalhe

## ⚠️ Ação necessária antes do merge

Gerente aplica migration via Supabase MCP:
```
scripts/migrations/20260414_add_professional_id_to_equipment.sql
```

Após aplicar, regenerar types com `npx supabase gen types` para remover os casts `as any`.

## Como testar

1. `/equipamentos/novo` → campo profissional é autocomplete, cliente preenche sozinho ao selecionar
2. `/equipamentos/[id]/editar` → se registro tem `professional_id`: badge pré-selecionado; se não tem: aviso amarelo + input de busca
3. `/profissionais/[id]` → aba Dados → card Equipamento exibe lista com link para cada equipamento
4. Card mostra "Nenhum equipamento vinculado." quando lista vazia

🤖 Generated with Claude Code