### PR TITLE
chore(CLEANUP-TYPES): remover casts as any pós-regeneração de types

### DIFF
--- a/src/actions/equipment.ts
+++ b/src/actions/equipment.ts
@@ -41,7 +41,6 @@ export async function createEquipment(
     return { error: 'Selecione um profissional cadastrado.' }
   }
 
-  // professional_id adicionado via migration — cast até tipos serem regenerados
   const payload = {
     professional_id: professionalId,
     professional_name: professionalName?.trim() || '',
@@ -52,8 +51,8 @@ export async function createEquipment(
     software_details: (formData.get('software_details') as string)?.trim() || null,
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: created, error } = await (supabase.from('equipment') as any)
+  const { data: created, error } = await supabase
+    .from('equipment')
     .insert(payload)
     .select()
     .single()
@@ -94,7 +93,6 @@ export async function updateEquipment(
     return { error: 'Selecione um profissional cadastrado.' }
   }
 
-  // professional_id adicionado via migration — cast até tipos serem regenerados
   const payload = {
     professional_id: professionalId,
     professional_name: professionalName?.trim() || '',
@@ -111,8 +109,8 @@ export async function updateEquipment(
     .eq('id', id)
     .single()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase.from('equipment') as any)
+  const { error } = await supabase
+    .from('equipment')
     .update(payload)
     .eq('id', id)
 

--- a/src/app/(dashboard)/equipamentos/[id]/editar/page.tsx
+++ b/src/app/(dashboard)/equipamentos/[id]/editar/page.tsx
@@ -18,8 +18,8 @@ export default async function EditEquipmentPage({ params }: EditEquipmentPagePro
   const { data: profile } = await supabase.from('profiles').select('role').eq('id', user.id).single()
   if (!canWrite(profile?.role)) redirect('/equipamentos')
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: equipment, error } = await (supabase.from('equipment') as any)
+  const { data: equipment, error } = await supabase
+    .from('equipment')
     .select('*')
     .eq('id', id)
     .single()
@@ -34,7 +34,7 @@ export default async function EditEquipmentPage({ params }: EditEquipmentPagePro
     .eq('status', 'Ativo')
     .order('name')
 
-  const profOptions = (professionals ?? []).map((p: { id: string; name: string; clients: { name: string } | null }) => ({
+  const profOptions = (professionals ?? []).map((p) => ({
     id: p.id,
     name: p.name,
     clientName: (p.clients as { name: string } | null)?.name ?? '',

--- a/src/app/(dashboard)/notificacoes/actions.ts
+++ b/src/app/(dashboard)/notificacoes/actions.ts
@@ -25,8 +25,7 @@ export async function markSistemaAsRead() {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  await (supabase as any)
+  await supabase
     .from('notifications')
     .update({ lida: true })
     .eq('user_id', user.id)

--- a/src/app/(dashboard)/notificacoes/page.tsx
+++ b/src/app/(dashboard)/notificacoes/page.tsx
@@ -7,16 +7,6 @@ export const metadata: Metadata = {
   title: 'Notificações',
 }
 
-interface SistemaNotif {
-  id: string
-  user_id: string
-  tipo: string
-  mensagem: string
-  link: string | null
-  lida: boolean
-  criado_em: string
-}
-
 const URGENCY_CONFIG: Record<string, { label: string; icon: string; bg: string; border: string; text: string }> = {
   expired: { label: 'Vencido',      icon: '🔴', bg: 'bg-red-50',    border: 'border-red-200',    text: 'text-red-700'    },
   critical: { label: '≤30 dias',    icon: '🔴', bg: 'bg-red-50',    border: 'border-red-200',    text: 'text-red-700'    },
@@ -50,10 +40,8 @@ export default async function NotificacoesPage({ searchParams }: NotificacoesPag
     .order('created_at', { ascending: false })
     .limit(100)
 
-  // Notificações do sistema (tabela não está nos tipos gerados ainda — cast necessário)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const supabaseAny = supabase as any
-  let sistemaQuery = supabaseAny
+  // Notificações do sistema
+  let sistemaQuery = supabase
     .from('notifications')
     .select('*')
     .order('criado_em', { ascending: false })
@@ -61,7 +49,7 @@ export default async function NotificacoesPage({ searchParams }: NotificacoesPag
 
   if (tipoFilter) sistemaQuery = sistemaQuery.eq('tipo', tipoFilter)
 
-  const { data: sistemaNotifs } = await sistemaQuery as { data: SistemaNotif[] | null }
+  const { data: sistemaNotifs } = await sistemaQuery
 
   const allContracts = contractNotifs ?? []
   const unreadContracts = allContracts.filter((n) => !n.read_at)

--- a/src/app/(dashboard)/profissionais/[id]/page.tsx
+++ b/src/app/(dashboard)/profissionais/[id]/page.tsx
@@ -59,9 +59,9 @@ export default async function ProfissionalDetailPage({ params }: ProfissionalDet
     notFound()
   }
 
-  // Busca equipamentos via professional_id (FK adicionada via migration)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: equipmentList } = await (supabase.from('equipment') as any)
+  // Busca equipamentos via professional_id
+  const { data: equipmentList } = await supabase
+    .from('equipment')
     .select('id, machine_type, machine_model, office_package, software_details, company')
     .eq('professional_id', professional.id)
     .order('created_at', { ascending: false })

--- a/src/components/layout/notification-bell.tsx
+++ b/src/components/layout/notification-bell.tsx
@@ -4,14 +4,12 @@ import Link from 'next/link'
 export async function NotificationBell() {
   const supabase = await createClient()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const supabaseAny = supabase as any
   const [{ count: countContratos }, { count: countNotif }] = await Promise.all([
     supabase
       .from('contract_notifications')
       .select('*', { count: 'exact', head: true })
       .is('read_at', null),
-    supabaseAny
+    supabase
       .from('notifications')
       .select('*', { count: 'exact', head: true })
       .eq('lida', false),

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -15,8 +15,7 @@ export async function insertNotification({
 }) {
   try {
     const admin = createAdminClient()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (admin as any).from('notifications').insert({ user_id, tipo, mensagem, link })
+    await admin.from('notifications').insert({ user_id, tipo, mensagem, link })
   } catch {
     // best-effort: não bloqueia a action principal
   }


### PR DESCRIPTION
## O que foi feito

Remoção de todos os workarounds `as any` + `eslint-disable` que haviam sido deixados após as migrations de `equipment.professional_id` e tabela `notifications`.

### Arquivos limpos

| Arquivo | Cast removido |
|---|---|
| `src/actions/equipment.ts` | `supabase.from('equipment') as any` (insert + update) |
| `src/app/(dashboard)/equipamentos/[id]/editar/page.tsx` | `supabase.from('equipment') as any` (select) |
| `src/app/(dashboard)/notificacoes/actions.ts` | `supabase as any` (update notifications) |
| `src/app/(dashboard)/notificacoes/page.tsx` | `supabaseAny` + interface `SistemaNotif` manual |
| `src/components/layout/notification-bell.tsx` | `supabaseAny` (count notifications) |
| `src/lib/notifications.ts` | `admin as any` (insert notifications) |
| `src/app/(dashboard)/profissionais/[id]/page.tsx` | `supabase.from('equipment') as any` (query por professional_id) |

## Verificação

- `grep -rn "as any" src/` — zero ocorrências relacionadas a notifications ou professional_id
- `npx tsc --noEmit` — sem erros
- `npm run lint` — zero erros nos arquivos alterados

🤖 Generated with Claude Code