### PR TITLE
fix(BUG-EQUIP-STATUS): filtro status 'Ativo' → 'ATIVO' no autocomplete de profissional

### DIFF
--- a/src/app/(dashboard)/equipamentos/[id]/editar/page.tsx
+++ b/src/app/(dashboard)/equipamentos/[id]/editar/page.tsx
@@ -31,7 +31,7 @@ export default async function EditEquipmentPage({ params }: EditEquipmentPagePro
   const { data: professionals } = await supabase
     .from('professionals')
     .select('id, name, clients(name)')
-    .eq('status', 'Ativo')
+    .eq('status', 'ATIVO')
     .order('name')
 
   const profOptions = (professionals ?? []).map((p) => ({

--- a/src/app/(dashboard)/equipamentos/novo/page.tsx
+++ b/src/app/(dashboard)/equipamentos/novo/page.tsx
@@ -15,7 +15,7 @@ export default async function NovoEquipamentoPage() {
   const { data: professionals } = await supabase
     .from('professionals')
     .select('id, name, clients(name)')
-    .eq('status', 'Ativo')
+    .eq('status', 'ATIVO')
     .order('name')
 
   const profOptions = (professionals ?? []).map(p => ({


### PR DESCRIPTION
## Causa

Query de profissionais usava `.eq('status', 'Ativo')` (title case), mas no banco todos têm `status = 'ATIVO'` (maiúsculas). Resultado: 0 registros → autocomplete sempre vazio.

## Fix

Corrigido em dois arquivos:
- `src/app/(dashboard)/equipamentos/novo/page.tsx`
- `src/app/(dashboard)/equipamentos/[id]/editar/page.tsx`

## Como testar

1. `/equipamentos/novo` → digitar nome no campo Profissional → lista aparece
2. Selecionar profissional → campo Cliente preenche automaticamente

🤖 Generated with Claude Code